### PR TITLE
ND-533 modularise bastion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,58 @@
 
 This repository was created to centralise the SSM Bastion Module which is required by two separate projects.
 
-More detail incoming.
+# SSM Bastion Access
+
+This bastion is not accessible via the public internet, it does not have a public ip. To connect to it one must use the SSM Session Manager.
+
+## Prerequisites
+
+- aws cli
+- [Session Manager plugin for the AWS CLI][plugin]
+
+On a Mac install the Session Manager plugin with [Homebrew][brew]
+
+```shell
+brew install --cask session-manager-plugin
+```
+
+## Connection from terminal
+
+You will need the `instance id` of the bastion EC2 instance - this useful command will return a table of instances
+
+```shell
+export AWS_PROFILE=the_awsprofile_name
+```
+
+```shell
+
+aws --profile ${AWS_PROFILE} \
+ec2 describe-instances \
+--query 'Reservations[].Instances[].[InstanceId,InstanceType,PublicIpAddress,Tags[?Key==`Name`]| [0].Value]' \
+--output table
+
+```
+
+Example result
+
+```shell
+---------------------------------------------------------------------------------------------------------------
+|                                              DescribeInstances                                              |
++---------------------+--------------+-----------------+------------------------------------------------------+
+|  i-0199asds08e827733|  t3.xlarge   |  1.2.3.4        |  MOJ-AW2-PAN01A                                      |
+|  i-074571ddc6dddddcc|  t2.micro    |  1.3.2.51       |  None                                                |
+|  i-0c4tttbbbb31fd3e6|  t2.nano     |  None           |  staff-infrastructure-development-net-svc-bastion    |
++---------------------+--------------+-----------------+------------------------------------------------------+
+
+```
+
+Grab the id and run the following command
+
+```shell
+aws --profile ${AWS_PROFILE} ssm start-session --target i-0c4tttbbbb31fd3e6
+```
+
+Now you will be logged in.
+
+[plugin]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+[brew]: https://brew.sh/

--- a/bastion.tf
+++ b/bastion.tf
@@ -1,6 +1,6 @@
 data "aws_ami" "ubuntu" {
   most_recent = true
-  owners      = ["683290208331"] # shared services account
+  owners      = var.ami_owners
 
   filter {
     name   = "name"

--- a/bastion.tf
+++ b/bastion.tf
@@ -1,0 +1,40 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["683290208331"] # shared services account
+
+  filter {
+    name   = "name"
+    values = ["${var.ami_name}"]
+  }
+
+  tags = {
+    deploy_to_all_environments = "True"
+  }
+}
+
+data "template_file" "user_data" {
+  template = file("${path.module}/user_data/user_data.sh")
+
+  vars = {
+    project_name = var.ami_name
+    rolename     = var.assume_role
+  }
+}
+
+resource "aws_instance" "bastion" {
+  ami                                  = data.aws_ami.ubuntu.id
+  instance_type                        = "t3a.small"
+  count                                = var.number_of_bastions
+  user_data                            = data.template_file.user_data.rendered
+  vpc_security_group_ids               = setunion(var.security_group_ids, [aws_security_group.bastion.id])
+  subnet_id                            = var.subnets[0]
+  monitoring                           = true
+  associate_public_ip_address          = var.associate_public_ip_address
+  iam_instance_profile                 = aws_iam_instance_profile.this.id
+  instance_initiated_shutdown_behavior = "terminate"
+  tags                                 = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/examples/rds-bastion/main.tf
+++ b/examples/rds-bastion/main.tf
@@ -1,0 +1,26 @@
+module "rds_admin_bastion_label" {
+  source       = "./modules/label"
+  service_name = "rds-admin-bastion"
+  owner_email  = var.owner_email
+}
+
+module "rds_admin_bastion" {
+  source                      = "git::https:github.com:ministryofjustice/diso-devops-module-ssm-bastion.git?depth=1"
+  ami_owners                  = ["${var.shared_services_account_id}"]
+  associate_public_ip_address = false
+  assume_role                 = local.s3-mojo_file_transfer_assume_role_arn
+  prefix                      = module.rds_admin_bastion_module_label.id
+  security_group_ids          = [module.admin.security_group_ids.admin_ecs]
+  subnets                     = module.admin_vpc.public_subnets
+  vpc_cidr_block              = module.admin_vpc.vpc.vpc_cidr_block
+  vpc_id                      = module.admin_vpc.vpc.vpc_id
+  tags                        = module.rds_admin_bastion_module_label.tags
+
+  providers = {
+    aws = aws.env
+  }
+
+  depends_on = [module.admin_vpc]
+  // Set in SSM parameter store, true or false to enable or disable this module.
+  count = var.enable_rds_admin_bastion == true ? 1 : 0
+}

--- a/examples/rds-bastion/main.tf
+++ b/examples/rds-bastion/main.tf
@@ -5,7 +5,7 @@ module "rds_admin_bastion_label" {
 }
 
 module "rds_admin_bastion" {
-  source                      = "git::https:github.com:ministryofjustice/diso-devops-module-ssm-bastion.git?depth=1"
+  source                      = "github.com/ministryofjustice/diso-devops-module-ssm-bastion.git?depth=1"
   ami_owners                  = ["${var.shared_services_account_id}"]
   associate_public_ip_address = false
   assume_role                 = local.s3-mojo_file_transfer_assume_role_arn

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,69 @@
+data "aws_iam_policy_document" "trust_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "ec2.amazonaws.com",
+        "ssm.amazonaws.com",
+      ]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "iam_instance_role" {
+  name               = local.name
+  assume_role_policy = data.aws_iam_policy_document.trust_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each   = toset(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"])
+  role       = aws_iam_role.iam_instance_role.name
+  policy_arn = each.key
+}
+
+data "aws_iam_policy_document" "kms_key_policy_iam_profile" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt"
+
+    ]
+    resources = [aws_kms_key.this.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "kms" {
+  role   = aws_iam_role.iam_instance_role.name
+  name   = "inline-policy-kms-access"
+  policy = data.aws_iam_policy_document.kms_key_policy_iam_profile.json
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = local.name
+  role = aws_iam_role.iam_instance_role.name
+}
+
+### S3 Bucket Acccess
+data "template_file" "bucket_access_policy" {
+  template = file("${path.module}/policies/bucket_access_policy_template.json")
+
+  vars = {
+    rolename = var.assume_role
+  }
+}
+
+resource "aws_iam_policy" "s3_bucket_access" {
+  name   = "${local.name}s3-bucket-access"
+  policy = data.template_file.bucket_access_policy.rendered
+}
+
+resource "aws_iam_role_policy_attachment" "s3_bucket_access" {
+  role       = aws_iam_role.iam_instance_role.name
+  policy_arn = aws_iam_policy.s3_bucket_access.arn
+}

--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,47 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "aws_kms_key" "this" {
+  description             = "KMS Key for cloudwatch SSM logging"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.kms_key_policy.json
+}
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.${data.aws_region.current.name}.amazonaws.com"
+      ]
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "bastion" {
+  value = aws_instance.bastion[*].id
+}

--- a/policies/bucket_access_policy_template.json
+++ b/policies/bucket_access_policy_template.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "${rolename}"
+    }
+  ]
+}

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,0 +1,18 @@
+resource "aws_security_group" "bastion" {
+  name        = var.prefix
+  description = "Allow SSH into bastion"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,0 +1,18 @@
+# Creating a random string for name interpolation
+resource "random_string" "this" {
+  length  = 5
+  special = false
+}
+
+locals {
+  name               = "${var.name}-${random_string.this.result}"
+  cloudwatch_prepend = "/aws/ec2/"
+  # We use basename of the id to ensure dependency-order
+  cloudwatch_loggroup_name = "${local.cloudwatch_prepend}${basename(aws_cloudwatch_log_group.ssm_log.id)}"
+}
+
+resource "aws_cloudwatch_log_group" "ssm_log" {
+  name              = "${local.cloudwatch_prepend}${local.name}"
+  retention_in_days = var.log_retention
+  kms_key_id        = aws_kms_key.this.arn
+}

--- a/user_data/user_data.sh
+++ b/user_data/user_data.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -x
+
+mkdir ~/.aws
+cat << 'EOF' > ~/.aws/config
+[profile s3-role]
+role_arn = ${rolename}
+credential_source = Ec2InstanceMetadata
+EOF

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "ami_name" {
 }
 
 variable "ami_owners" {
-  type    = list(any)
+  type        = list(any)
   description = "The owning AWS Account ID of the ami."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,11 @@ variable "ami_name" {
   default     = "diso-devops/bastion/ubuntu-jammy-22.04-amd64-server-generic-*"
 }
 
+variable "ami_owners" {
+  type    = list(any)
+  description = "The owning AWS Account ID of the ami."
+}
+
 variable "assume_role" {
   type        = string
   description = "The name for the role the instance assumes for S3 bucket access"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,57 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr_block" {
+  type = string
+}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "prefix" {
+  type = string
+}
+
+variable "name" {
+  type        = string
+  description = "The name to be interpolated, defaults to bastion-ssm-iam"
+  default     = "bastion-ssm-iam"
+}
+
+variable "log_retention" {
+  type        = number
+  description = "The amount of days the logs need to be kept"
+  default     = 90
+}
+
+variable "number_of_bastions" {
+  type    = number
+  default = 1
+}
+
+variable "security_group_ids" {
+  type    = list(any)
+  default = []
+}
+
+variable "ami_name" {
+  type        = string
+  description = "The ami name"
+  default     = "diso-devops/bastion/ubuntu-jammy-22.04-amd64-server-generic-*"
+}
+
+variable "assume_role" {
+  type        = string
+  description = "The name for the role the instance assumes for S3 bucket access"
+}
+
+variable "associate_public_ip_address" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
This module is a slight improvement on that currently in use, however it is centralised which results in lower maintenance overhead.

There are three changes to the existing implementation which need to be done which then results in transparent change (no resources are updated or recreated on Terraform apply).

1. Change source: `source = "github.com/ministryofjustice/diso-devops-module-ssm-bastion.git?depth=1&ref=(git_hash)`
2. Add var : `ami_owners = ["${var.shared_services_account_id}"]`
3. Amend var name from `private_subnets` to `subnets`