### PR TITLE
Update CODEOWNERS to network-automation team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/nvvs-devops-admins
+* @ministryofjustice/network-automation


### PR DESCRIPTION
## What
Updates CODEOWNERS to reflect the team rename.

## Changes
- `.github/CODEOWNERS` — replaced `@ministryofjustice/nvvs-devops-admins` with `@ministryofjustice/network-automation`