### PR TITLE
ND-2003-update-CODEOWNERS-for-network-automation-teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/nvvs-devops-admins
+* @ministryofjustice/network-automation-admins @ministryofjustice/network-automation-writers


### PR DESCRIPTION
Updated .github/CODEOWNERS to replace legacy nvvs-devops-admins and nvvs-devops-writers with network-automation-admins and network-automation-writers.

This change allows both Network Automation teams to review and approve applicable pull requests as part of ND-2003.